### PR TITLE
Fixed Virgin Pulse link not being absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 #### What Am I Up To?
 
-- 🖥 Working as a Software Engineering Intern @ [Virgin Pulse](www.virginpulse.com)
+- 🖥 Working as a Software Engineering Intern @ [Virgin Pulse](https://www.virginpulse.com)
 
 - 📈 Recently won 3rd place in the Grant Thornton GT-IDEA case competition (Environmental, Social, Governance Implications on Healthcare Ops)
 


### PR DESCRIPTION
Previously the link tried to open as a relative path to whichever Github location the user was currently at (e.g. `https://github.com/khalea/khalea/blob/master/www.virginpulse.com`).